### PR TITLE
Feature kakao

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,9 +11,23 @@ datasource db {
 }
 
 model Users {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
+  userId        Int     @id @default(autoincrement())
+  kakaoId       Int?           
+  name          String        
+  email         String         @unique
+  password      String?         
+  Role          String         @default("user")
+  gender        gender
+  age           Int?
+  oneliner      String?         
+  createdAt     DateTime       @default(now()) 
+  updatedAt     DateTime       @updatedAt 
+  
 
   @@map("users")
+}
+
+enum gender {
+  male
+  female
 }

--- a/src/routes/kakao.router.js
+++ b/src/routes/kakao.router.js
@@ -4,17 +4,21 @@ import jwt from "jsonwebtoken";
 
 const router = express.Router();
 
-router.get("/kakao/sign-in", async (req, res) => {
-  const baseUrl = "https://kauth.kakao.com/oauth/authorize";
-  const config = {
-    client_id: process.env.KAKAO_ID,
-    redirect_uri: "http://localhost:3000/api/kakao/userInfo",
-    response_type: "code",
-  };
-  const params = new URLSearchParams(config).toString();
+router.get("/kakao/sign-in", async (req, res, next) => {
+  try {
+    const baseUrl = "https://kauth.kakao.com/oauth/authorize";
+    const config = {
+      client_id: process.env.KAKAO_ID,
+      redirect_uri: "http://localhost:3000/api/kakao/userInfo",
+      response_type: "code",
+    };
+    const params = new URLSearchParams(config).toString();
 
-  const finalUrl = `${baseUrl}?${params}`;
-  return res.redirect(finalUrl);
+    const finalUrl = `${baseUrl}?${params}`;
+    return res.redirect(finalUrl);
+  } catch (error) {
+    next(error);
+  }
 });
 
 router.get("/kakao/userInfo", async (req, res, next) => {
@@ -52,7 +56,7 @@ router.get("/kakao/userInfo", async (req, res, next) => {
       });
       // 카카오 로그인을 하지 않고 일반 가입한 사용자가 이메일이 같으면 오류코드를 띄워준다.
       if (user && !user.kakaoId) {
-        return res.status(401).json({ message: "이미 가입한 이메일입니다." });
+        return res.status(400).json({ message: "이미 가입한 이메일입니다." });
       }
       if (!user) {
         await prisma.users.create({

--- a/src/routes/kakao.router.js
+++ b/src/routes/kakao.router.js
@@ -1,5 +1,5 @@
 import express from "express";
-//import { prisma } from "../utils/prisma/index.js";
+import { prisma } from "../utils/prisma/index.js";
 import jwt from "jsonwebtoken";
 
 const router = express.Router();
@@ -14,7 +14,6 @@ router.get("/kakao/sign-in", async (req, res) => {
   const params = new URLSearchParams(config).toString();
 
   const finalUrl = `${baseUrl}?${params}`;
-  console.log(finalUrl);
   return res.redirect(finalUrl);
 });
 
@@ -22,14 +21,15 @@ router.get("/kakao/userInfo", async (req, res, next) => {
   try {
     const baseUrl = "https://kauth.kakao.com/oauth/token";
     const config = {
-      client_id: process.env.KAKAO_ID,
-      client_secret: process.env.KAKAO_SECRET,
+      client_id: process.env.KAKAO_ID, //restAPI 키
+      client_secret: process.env.KAKAO_SECRET, //보안 키
       grant_type: "authorization_code",
       redirect_uri: "http://localhost:3000/api/kakao/userInfo",
       code: req.query.code,
     };
     const params = new URLSearchParams(config).toString();
     const finalUrl = `${baseUrl}?${params}`;
+    console.log(finalUrl);
     const kakaoTokenRequest = await fetch(finalUrl, {
       method: "POST",
       headers: {
@@ -50,69 +50,49 @@ router.get("/kakao/userInfo", async (req, res, next) => {
       const user = await prisma.users.findFirst({
         where: { email: userData.kakao_account.email },
       });
+      // 카카오 로그인을 하지 않고 일반 가입한 사용자가 이메일이 같으면 오류코드를 띄워준다.
+      if (user && !user.kakaoId) {
+        return res.status(401).json({ message: "이미 가입한 이메일입니다." });
+      }
       if (!user) {
         await prisma.users.create({
           data: {
             kakaoId: userData.id,
             name: userData.kakao_account.name,
             email: userData.kakao_account.email,
+            gender: userData.kakao_account.gender,
           },
         });
       }
-      return res.json({ data: user });
+
+      // 엑세스 토큰과 리프레시 토큰 발급
+      const accessToken = jwt.sign(
+        { userId: user.userId },
+        process.env.ACCESS_TOKEN_SECRET_KEY,
+        {
+          expiresIn: "12h",
+        }
+      );
+      const refreshToken = jwt.sign(
+        { userId: user.userId },
+        process.env.REFRESH_TOKEN_SECRET_KEY,
+        {
+          expiresIn: "7d",
+        }
+      );
+
+      // 쿠키에 토큰 할당
+      res.cookie("authorization", `Bearer ${accessToken}`);
+      res.cookie("refreshToken", refreshToken);
+
+      // 유저 정보와 성공메시지를 반환
+      return res.json({ data: user, message: "로그인에 성공하셨습니다." });
     } else {
       // 엑세스 토큰이 없으면 로그인페이지로 리다이렉트
-      return res.redirect("api/kakao/sign-in");
+      return res.redirect("/api/kakao/sign-in");
     }
   } catch (error) {
     next(error);
-  }
-});
-
-router.post("/kakao/sign-in", async (req, res, next) => {
-  try {
-    const { kakaoId } = req.body;
-    const user = await prisma.users.findFirst({
-      where: { kakaoId: +kakaoId },
-    });
-
-    if (!user) {
-      return res.status(401).json({ message: "존재하지 않는 사용자입니다." });
-    }
-
-    // 엑세스 토큰과 리프레시 토큰 발급
-    const accessToken = jwt.sign(
-      { userId: user.userId },
-      process.env.ACCESS_TOKEN_SECRET_KEY,
-      {
-        expiresIn: "12h",
-      }
-    );
-    const refreshToken = jwt.sign(
-      { userId: user.userId },
-      process.env.REFRESH_TOKEN_SECRET_KEY,
-      {
-        expiresIn: "7d",
-      }
-    );
-
-    // 리프레시 토큰 저장
-    await prisma.refreshToken.create({
-      data: {
-        token: refreshToken,
-        userId: user.userId,
-        ip: req.ip,
-        userAgent: req.headers["user-agent"],
-      },
-    });
-
-    // 쿠키에 토큰 할당
-    res.cookie("authorization", `Bearer ${accessToken}`);
-    res.cookie("refreshToken", refreshToken);
-
-    return res.status(200).json({ message: "로그인에 성공하셨습니다." });
-  } catch (err) {
-    next(err);
   }
 });
 


### PR DESCRIPTION
- api/kakao/sign-in 에서 요청을 하면 카카오 서버에서 로그인 화면을 줍니다.
- 로그인해서 카카오 회원임이 인증되면 인가코드를 발행해주고 api/kakao/userInfo로 redirect합니다.
- 리다이렉트한 url에서[ oauth/token]으로 토큰 발급을 요청하고 받아오면 엑세스 토큰으로 유저 정보를 받아옵니다.
- 요청한 정보는 대략 이렇습니다. 
![image](https://github.com/Jindonglee/Grown_Ups-Project/assets/127701418/b721bf89-d103-42ca-bb64-ccc4522e126e)

- db에 정보가 있는지 email을 기준으로 확인합니다.
- 카카오 로그인을 사용하지 않고 동일한 이메일로 가입한 사람이 있다면 오류메시지를 반환해 줍니다.
- 사용자가 없다면 db에 유저정보를 생성합니다.
- 엑세스토큰과 리프레시토큰을 발급해 쿠키에 저장합니다.
- 유저 데이터와 "로그인에 성공하셨습니다" 메시지를 반환합니다.
- 카카오 로그인이 어떤 방식으로 이루어 지는 지는 [https://developers.kakao.com/console/app/1031850/product/login/scope](url) 에서 확인하실 수 있습니다. 
